### PR TITLE
BAH-1852 Upgrade openmrs version from 2.4.2 to 2.5.0 in rules-engine module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</modules>
 
 	<properties>
-		<openMRSVersion>2.4.2</openMRSVersion>
+		<openMRSVersion>2.5.0</openMRSVersion>
 		<bahmniJavaUtilsVersion>0.94.2</bahmniJavaUtilsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<junitVersion>4.13</junitVersion>


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1852
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0


### Testing
The screenshots for successful compilation have been added on the ticket.