### PR TITLE
Bah 1649 - Upgrading rules-engine module artefact version to 0.94.1-SNAPSHOT

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ master ]
+    branches: [ master, OMRS-master-2.4 ]
   
 jobs:
   build-publish-package:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,7 +1,7 @@
 name: Build and Publish package
 on:
   push:
-    branches: [ master, OMRS-master-2.4 ]
+    branches: [ OMRS-master-2.4 ]
   
 jobs:
   build-publish-package:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -127,6 +127,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javaxServletVersion}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- End OpenMRS core -->
 
     </dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>rulesengine</artifactId>
-        <version>0.94-SNAPSHOT</version>
+        <version>0.94.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rulesengine-api</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>rulesengine</artifactId>
-		<version>0.94-SNAPSHOT</version>
+		<version>0.94.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rulesengine-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>rulesengine</artifactId>
-	<version>0.94-SNAPSHOT</version>
+	<version>0.94.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Rules Engine Module</name>
 	<description>Helps to calculate dose based on dosing rules.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<junitVersion>4.13</junitVersion>
 		<powerMockVersion>2.0.7</powerMockVersion>
 		<log4jVersion>2.17.1</log4jVersion>
+		<javaxServletVersion>4.0.1</javaxServletVersion>
 	</properties>
 
 	<dependencyManagement>
@@ -66,6 +67,12 @@
 				<version>${openMRSVersion}</version>
 				<type>jar</type>
 				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>servlet-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
This PR is about

- Upgrading rules-engine module artefact version to 0.94.1-SNAPSHOT
- Adds OMRS-master-2.4 branch in Github on push workflow
- Adds javax servlet-api dependency to resolve HttpServletResponse compile time issue