### PR TITLE
BAH-2849 | adding a dummy class in the omod file for javadoc jar

### DIFF
--- a/omod/src/main/java/org/openmrs/module/rulesengine/ModuleDescriptor.java
+++ b/omod/src/main/java/org/openmrs/module/rulesengine/ModuleDescriptor.java
@@ -1,0 +1,4 @@
+package org.openmrs.module.rulesengine;
+
+public class ModuleDescriptor {
+}


### PR DESCRIPTION
omod is a different module that generates jar and nexus demands that any jar must have javadoc jar associated. 