### PR TITLE
BAH-4541|Updated bahmniJavaUtilsVersion version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
 	<properties>
 		<openMRSVersion>2.4.2</openMRSVersion>
-		<bahmniJavaUtilsVersion>0.94.4-SNAPSHOT</bahmniJavaUtilsVersion>
+		<bahmniJavaUtilsVersion>1.0.0</bahmniJavaUtilsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<junitVersion>4.13</junitVersion>
 		<powerMockVersion>2.0.7</powerMockVersion>


### PR DESCRIPTION
Updated bahmni-java-utils release version to 1.0.0 instead of snapshot