### PR TITLE
Sasi | BAH-4576 | Enhance rules extenstion path derivate logic

### DIFF
--- a/api/src/main/java/org/openmrs/module/rulesengine/engine/RulesEngineImpl.java
+++ b/api/src/main/java/org/openmrs/module/rulesengine/engine/RulesEngineImpl.java
@@ -86,7 +86,7 @@ public class RulesEngineImpl implements RulesEngine {
     }
 
     private File[] getExtendedRuleFiles() {
-        File folder = new File(getRulesEngineExtensionPath());
+        File folder = new File(OpenmrsUtil.getApplicationDataDirectory(), getRulesEngineExtensionPath());
         File[] listOfFiles = folder.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String filename) {
                 return filename.endsWith(".groovy");
@@ -96,8 +96,7 @@ public class RulesEngineImpl implements RulesEngine {
     }
 
     private String getRulesEngineExtensionPath() {
-        String ruleFilePath = OpenmrsUtil.getApplicationDataDirectory() +
-                "bahmni_config" + File.separator + "openmrs" + File.separator +
+        String ruleFilePath = "bahmni_config" + File.separator + "openmrs" + File.separator +
                 rulesEngineExtensionPath;
         return ruleFilePath;
     }


### PR DESCRIPTION
Currently, the system uses String concatenation to prepare a file path, which leads to issues in detecting new rules because of incorrect path.

In CURE case application data directory path is /openmrs/data and the current logic appends bahmni_config without slash and thus resulting in incorrect path /openmrs/databahmni_config.