### PR TITLE
BAH-4739 | Add new dose units enum constants and fix extension path derivation logic

### DIFF
--- a/api/src/main/java/org/openmrs/module/rulesengine/domain/Dose.java
+++ b/api/src/main/java/org/openmrs/module/rulesengine/domain/Dose.java
@@ -20,7 +20,9 @@ public class Dose {
     }
 
     public enum DoseUnit {
-        mg
+        mg,
+        mcg,
+        ml
     }
 
     public String getDrugName() {

--- a/api/src/main/java/org/openmrs/module/rulesengine/engine/RulesEngineImpl.java
+++ b/api/src/main/java/org/openmrs/module/rulesengine/engine/RulesEngineImpl.java
@@ -86,7 +86,7 @@ public class RulesEngineImpl implements RulesEngine {
     }
 
     private File[] getExtendedRuleFiles() {
-        File folder = new File(getRulesEngineExtensionPath());
+        File folder = new File(OpenmrsUtil.getApplicationDataDirectory(), getRulesEngineExtensionPath());
         File[] listOfFiles = folder.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String filename) {
                 return filename.endsWith(".groovy");
@@ -96,8 +96,7 @@ public class RulesEngineImpl implements RulesEngine {
     }
 
     private String getRulesEngineExtensionPath() {
-        String ruleFilePath = OpenmrsUtil.getApplicationDataDirectory() +
-                "bahmni_config" + File.separator + "openmrs" + File.separator +
+        String ruleFilePath =  "bahmni_config" + File.separator + "openmrs" + File.separator +
                 rulesEngineExtensionPath;
         return ruleFilePath;
     }


### PR DESCRIPTION
**Description:**

  Summary

  - Added MCG and ML enum constants to the Dose domain class to support the new mcg/kg and ml/kg dosage rules
  - Fixed extension path derivation logic in RulesEngineImpl to correctly resolve the rules engine execution path

  **Test plan**

  - Verify mcg/kg rule calculates dose as Dose Value × Latest Patient Weight (kg) and resolves unit to mcg
  - Verify ml/kg rule calculates dose as Dose Value × Latest Patient Weight (kg) and resolves unit to ml
  - Verify existing mg/kg rule is unaffected